### PR TITLE
Add "eauth" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Salt::Api.configure do |config|
   config.hostname = "salt.example.com"
   config.username = "user1"
   config.password = "password"
+  config.eauth = "ldap"
 end
 
 puts Salt::Api.minions

--- a/lib/salt/api/client.rb
+++ b/lib/salt/api/client.rb
@@ -16,7 +16,7 @@ module Salt
       def login
         req = Net::HTTP::Post.new("/login")
         req.set_form_data({
-          'eauth' => 'pam',
+          'eauth' => eauth,
           'username' => username,
           'password' => password
         })

--- a/lib/salt/api/configure.rb
+++ b/lib/salt/api/configure.rb
@@ -6,6 +6,7 @@ module Salt
         :username,
         :password,
         :timeout,
+        :eauth,
         :port,
         :use_ssl
       ].freeze
@@ -16,6 +17,7 @@ module Salt
         @hostname = "salt"
         @port = 8000
         @use_ssl = true
+        @eauth = 'pam'
       end
 
       def configure


### PR DESCRIPTION
Hello !

I've added an "eauth" configuration parameter, to support authentication when LDAP is enabled on salt-server side.
It defaults to "pam" to not break things.

It works on my salt setup, with the snippet present in the README.
