### PR TITLE
Added support for /jobs endpoint

### DIFF
--- a/lib/salt/api.rb
+++ b/lib/salt/api.rb
@@ -4,6 +4,7 @@ require "salt/api/client"
 require "salt/api/minions"
 require "salt/api/events"
 require "salt/api/run"
+require "salt/api/jobs"
 
 module Salt
   module Api
@@ -12,5 +13,6 @@ module Salt
     extend Minions
     extend Events
     extend Run
+    extend Jobs
   end
 end

--- a/lib/salt/api/jobs.rb
+++ b/lib/salt/api/jobs.rb
@@ -1,0 +1,15 @@
+module Salt
+  module Api
+    module Jobs
+      def jobs(jid = nil)
+        req = Net::HTTP::Get.new(jid.nil? ? "/jobs" : "/jobs/#{jid}")
+        req['X-Auth-Token'] = token
+        req['Accept'] = "application/x-yaml"
+        resp = client.request(req)
+        raise "Get request to /jobs failed (#{resp})" unless resp.kind_of? Net::HTTPSuccess
+        parsed_resp = YAML.load(resp.body)["return"]
+        return parsed_resp
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the `/jobs` endpoint, adding `Salt::Api.jobs()`. This method takes an optional argument, `jid`. Without the argument, the method should return all jobs from the API; with the `jid` argument, it should return just the job with the matching JID.

EDIT: Updated the title, it was erroneous.
