### PR TITLE
Add openssl to client

### DIFF
--- a/lib/salt/api/client.rb
+++ b/lib/salt/api/client.rb
@@ -1,5 +1,6 @@
 require 'net/http'
 require 'yaml'
+require 'openssl'
 
 module Salt
   module Api


### PR DESCRIPTION
I add openssl requirement, because client cannot start.

```
/Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/client.rb:12:in `block in client': uninitialized constant Salt::Api::Client::OpenSSL (NameError)
Did you mean?  OpenStruct
	from /Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/client.rb:8:in `tap'
	from /Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/client.rb:8:in `client'
	from /Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/client.rb:24:in `login'
	from /Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/client.rb:32:in `token'
	from /Users/tomcsi/.rvm/gems/ruby-2.3.1/gems/salt-api-0.1.5/lib/salt/api/run.rb:6:in `run'
	from test.rb:11:in `<main>'
```